### PR TITLE
36-stack-top-incrementdecrement-does-not-match-when-pushingpopping de…

### DIFF
--- a/src/Stack.c
+++ b/src/Stack.c
@@ -139,8 +139,12 @@ bool Stack_Pop(Stack_t *const stack, void *const item)
 
   if (Stack_Peek(stack, item))
   {
-    stack->Top -= stack->ItemSize;
     stack->Items--;
+
+    if (stack->Items > 0UL)
+    {
+      stack->Top -= stack->ItemSize;
+    }
 
     popped = true;
   }


### PR DESCRIPTION
…crement top when popping after decrementing item count and checking new item is greater than zero